### PR TITLE
Added attr_accessible to registration_id on Gcm::Device

### DIFF
--- a/lib/gcm_on_rails/app/models/gcm/device.rb
+++ b/lib/gcm_on_rails/app/models/gcm/device.rb
@@ -11,6 +11,8 @@
 class Gcm::Device < Gcm::Base
   self.table_name = "gcm_devices"
 
+  attr_accessible :registration_id
+
   has_many :notifications, :class_name => 'Gcm::Notification', :dependent => :destroy
   validates_presence_of :registration_id
   validates_uniqueness_of :registration_id


### PR DESCRIPTION
The instructions (Gcm::Device.create(registration_id: "FOOBAR") did not work without it.
