### PR TITLE
fix bug with invalid json being generated

### DIFF
--- a/lib/gcm_on_rails/app/models/gcm/notification.rb
+++ b/lib/gcm_on_rails/app/models/gcm/notification.rb
@@ -45,7 +45,8 @@ class Gcm::Notification < Gcm::Base
             response = Gcm::Connection.send_notification(notification, api_key, format)
             logger.info "response = #{response.inspect}"
 
-            if response[:code] == 200
+            case response[:code]
+            when 200
               if response[:message].nil?
                 # TODO - Making this assumption might not be right. HTTP status code 200 does not really signify success
                 # if Gcm servers returned nil for the message
@@ -62,34 +63,36 @@ class Gcm::Notification < Gcm::Base
 
 
               case error
-                when "MissingRegistration"
-                  ex = Gcm::Errors::MissingRegistration.new(response[:message])
-                  logger.warn("#{ex.message}, destroying gcm_device with id #{notification.device.id}")
-                  notification.device.destroy
-                when "InvalidRegistration"
-                  ex = Gcm::Errors::InvalidRegistration.new(response[:message])
-                  logger.warn("#{ex.message}, destroying gcm_device with id #{notification.device.id}")
-                  notification.device.destroy
-                when "MismatchedSenderId"
-                  ex = Gcm::Errors::MismatchSenderId.new(response[:message])
-                  logger.warn(ex.message)
-                when "NotRegistered"
-                  ex = Gcm::Errors::NotRegistered.new(response[:message])
-                  logger.warn("#{ex.message}, destroying gcm_device with id #{notification.device.id}")
-                  notification.device.destroy
-                when "MessageTooBig"
-                  ex = Gcm::Errors::MessageTooBig.new(response[:message])
-                  logger.warn(ex.message)
-                else
-                  notification.sent_at = Time.now
-                  notification.save!
+              when "MissingRegistration"
+                ex = Gcm::Errors::MissingRegistration.new(response[:message])
+                logger.warn("#{ex.message}, destroying gcm_device with id #{notification.device.id}")
+                notification.device.destroy
+              when "InvalidRegistration"
+                ex = Gcm::Errors::InvalidRegistration.new(response[:message])
+                logger.warn("#{ex.message}, destroying gcm_device with id #{notification.device.id}")
+                notification.device.destroy
+              when "MismatchedSenderId"
+                ex = Gcm::Errors::MismatchSenderId.new(response[:message])
+                logger.warn(ex.message)
+              when "NotRegistered"
+                ex = Gcm::Errors::NotRegistered.new(response[:message])
+                logger.warn("#{ex.message}, destroying gcm_device with id #{notification.device.id}")
+                notification.device.destroy
+              when "MessageTooBig"
+                ex = Gcm::Errors::MessageTooBig.new(response[:message])
+                logger.warn(ex.message)
+              else
+                notification.sent_at = Time.now
               end
-            elsif response[:code] == 401
+              notification.save!
+            when 400
+              raise Gcm::Errors::InvalidJSON.new(message_data)
+            when 401
               raise Gcm::Errors::InvalidAuthToken.new(message_data)
-            elsif response[:code] == 503
-              raise Gcm::Errors::ServiceUnavailable.new(message_data)
-            elsif response[:code] == 500
+            when 500
               raise Gcm::Errors::InternalServerError.new(message_data)
+            when 503
+              raise Gcm::Errors::ServiceUnavailable.new(message_data)
             end
 
           end

--- a/lib/gcm_on_rails/gcm_on_rails.rb
+++ b/lib/gcm_on_rails/gcm_on_rails.rb
@@ -4,6 +4,13 @@ require 'uri'
 module Gcm
   module Errors
 
+    # Invalid JSON
+    class InvalidJSON < StandardError
+      def initialize(message) # :nodoc:
+        super("Invalid JSON: '#{message}'")
+      end
+    end
+
     # Missing registration_id.
     class MissingRegistration < StandardError
       def initialize(message) # :nodoc:

--- a/lib/gcm_on_rails/libs/connection.rb
+++ b/lib/gcm_on_rails/libs/connection.rb
@@ -9,9 +9,13 @@ module Gcm
           headers = {"Content-Type" => "application/json",
                      "Authorization" => "key=#{api_key}"}
 
-          data = notification.data.merge({:collapse_key => notification.collapse_key}) unless notification.collapse_key.nil?
-          data = data.merge({:delay_while_idle => notification.delay_while_idle}) unless notification.delay_while_idle.nil?
-          data = data.merge({:time_to_live => notification.time_to_live}) unless notification.time_to_live.nil?
+          data = {
+            data: notification.data,
+            registration_ids: [notification.device.registration_id]
+          }
+          data = data.merge({collapse_key: notification.collapse_key}) unless notification.collapse_key.nil?
+          data = data.merge({delay_while_idle: notification.delay_while_idle}) unless notification.delay_while_idle.nil?
+          data = data.merge({time_to_live: notification.time_to_live}) unless notification.time_to_live.nil?
           data = data.to_json
         else   #plain text format
           headers = {"Content-Type" => "application/x-www-form-urlencoded;charset=UTF-8",


### PR DESCRIPTION
This fixes a bug where the JSON being sent to Google was missing 2 attributes.  Google would return a status code of 400, indicating there was a problem with the JSON.  Note: I haven't tested the case where Notification.data is nil.
