### PR TITLE
Fix the bug of "if" in validates_presence_of :collapse_key

### DIFF
--- a/lib/gcm_on_rails/app/models/gcm/notification.rb
+++ b/lib/gcm_on_rails/app/models/gcm/notification.rb
@@ -6,7 +6,7 @@ class Gcm::Notification < Gcm::Base
   serialize :data
 
   belongs_to :device, :class_name => 'Gcm::Device'
-  validates_presence_of :collapse_key if :time_to_live?
+  validates_presence_of :collapse_key, if: :time_to_live?
 
   class << self
     # Opens a connection to the Google GCM server and attempts to batch deliver


### PR DESCRIPTION
`:time_to_live?` is always evaluated as `true`, so `validates_presence_of :collapse_key` is always enabled in spite of whether `time_to_live` is `nil` or not.

You might fix it from `if` to `, if:`.

References;
- http://apidock.com/rails/ActiveRecord/Validations/ClassMethods/validates_presence_of
- http://stackoverflow.com/questions/10501401/validates-presence-of-if-condition-on-rails-3-2-and-mongoid-simple-form
