### PR TITLE
Make data not to be nil when collapse_key is nil

### DIFF
--- a/lib/gcm_on_rails/libs/connection.rb
+++ b/lib/gcm_on_rails/libs/connection.rb
@@ -9,7 +9,8 @@ module Gcm
           headers = {"Content-Type" => "application/json",
                      "Authorization" => "key=#{api_key}"}
 
-          data = notification.data.merge({:collapse_key => notification.collapse_key}) unless notification.collapse_key.nil?
+          data = notification.data
+          data = data.merge({:collapse_key => notification.collapse_key}) unless notification.collapse_key.nil?
           data = data.merge({:delay_while_idle => notification.delay_while_idle}) unless notification.delay_while_idle.nil?
           data = data.merge({:time_to_live => notification.time_to_live}) unless notification.time_to_live.nil?
           data = data.to_json


### PR DESCRIPTION
If the pull request #28 is merged, `collapse_key` of `notification` can be nil.

When it is nil, `data = notification.data.merge({:collapse_key => notification.collapse_key})` will not be executed, and `data` will become nil.
Then, the next step of `data = data.merge({ ...` makes an error, because `data` is nil.

So, I modified it so that `data` is initialized by `notification.data` always.
