### PR TITLE
Rails 4 compatibility upgrade

### DIFF
--- a/lib/gcm_on_rails/app/models/gcm/notification.rb
+++ b/lib/gcm_on_rails/app/models/gcm/notification.rb
@@ -28,7 +28,7 @@ class Gcm::Notification < Gcm::Base
     # {:message=>"{\"multicast_id\":6085691036338669615,\"success\":1,\"failure\":0,\"canonical_ids\":0,\"results\":[{\"message_id\":\"0:1349723376618187%d702725e98d39af3\"}]}", :code=>200}
     #
     #
-    def send_notifications(notifications = Gcm::Notification.all(:conditions => {:sent_at => nil}, :joins => :device, :readonly => false))
+    def send_notifications(notifications = Gcm::Notification.joins(:device).where(sent_at: nil))
 
       if configatron.gcm_on_rails.delivery_format and configatron.gcm_on_rails.delivery_format == 'plain_text'
         format = "plain_text"


### PR DESCRIPTION
I've altered the old active record call to use the new AR methods instead of the old finder hash options method in the notification model. This should make it compatible with Rails 4. It has been tested on my system with a Rails 4 application and appears to function successfully.
